### PR TITLE
Fixes conversion from ArrayBuffer to std::vector

### DIFF
--- a/compileLibraw.sh
+++ b/compileLibraw.sh
@@ -13,7 +13,7 @@ mkdir includes
 echo -e "\n==> Cloning LCMS from GitHub..."
 git clone https://github.com/mm2/Little-CMS.git lcms2
 cd lcms2
-glibtoolize
+libtoolize
 autoreconf -fi
 # 2) Configure and make with Emscripten
 emconfigure ./configure --host=wasm32-unknown-emscripten \
@@ -36,7 +36,7 @@ pushd LibRawSource
 
 echo -e "\n==> Generating configure script from configure.ac..."
 # Generate ./configure from configure.ac
-glibtoolize
+libtoolize
 autoreconf -i
 
 #---------------------------------------------------------------------------------

--- a/worker.js
+++ b/worker.js
@@ -5,7 +5,7 @@ let LibRawClass;
 let raw;
 
 async function initLibRaw() {
-	ready = (async ()=>{
+	ready = (async () => {
 		const module = await LibRawModule();
 		LibRawClass = module.LibRaw;
 		raw = new LibRawClass();
@@ -14,17 +14,23 @@ async function initLibRaw() {
 
 initLibRaw();
 
+function isTypedArray(obj) {
+	return ArrayBuffer.isView(obj) && !(obj instanceof DataView);
+}
+
 self.onmessage = async (event) => {
-  const { fn, args } = event.data;
-  try {
-	await ready;
-    let out = raw[fn](...args);
-    self.postMessage({out},  (Array.isArray(out)?out:(typeof out=='object'?Object.values(out):[])).map(a=>{
-		if([ArrayBuffer, Uint8Array, Int8Array, Uint16Array, Int16Array, Uint32Array, Int32Array, Float32Array, Float64Array].some(b=>a instanceof b)) { // Transfer buffer
-			return a.buffer;
+	const {fn, args} = event.data;
+	try {
+		await ready;
+		const out = raw[fn](...args);
+		const transferList = [];
+		for (const key in out) {
+			const value = out[key];
+			if (isTypedArray(value))
+				transferList.push(value.buffer);
 		}
-	}).filter(a=>a));
-  } catch (err) {
-    self.postMessage({ error: err.message });
-  }
+		self.postMessage({out}, transferList);
+	} catch (err) {
+		self.postMessage({error: err.message});
+	}
 };


### PR DESCRIPTION
## Problem
### The current implementation of toNativeVector has two critical issues:

**Severe Performance Bottleneck:** The byte-by-byte copying approach causes a JS/WASM boundary crossing for every single byte, making it extremely inefficient for large RAW files.
**Memory Safety Bug:** The std::vector created in the open method is destroyed when the function exits, leaving LibRaw with a dangling pointer to freed memory. This can cause crashes or undefined behavior since LibRaw's open_buffer does not copy the buffer data internally.

## Solution
### This PR implements two key improvements:
**1. Bulk Memory Transfer:** Replaces inefficient byte-by-byte copying with Emscripten's optimized bulk memory operations.

**2. Proper Memory Management**: Stores the buffer as a class member to ensure it remains valid for LibRaw's lifetime

## Performance Impact
Before: 4,600ms to open a typical ARW file
After: 123ms to open the same file
Improvement: ~37x faster (97% reduction in processing time)
Tested on M2 Pro processor in Chrome browser

## Breaking Changes
None - this is a pure implementation improvement with no API changes.