### PR TITLE
CI/CD: build-test + commit-back + release-on-tag (closes #22)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,93 @@
+name: Build artifacts
+
+# On push to main (when something that affects the build changes), rebuild the
+# wasm from source, run the tests, and commit the regenerated artifacts back to
+# main. This keeps the repo's prebuilt binaries authoritative (built by CI, not
+# by contributors) while preserving "git clone and it just works".
+#
+# Recursion note: the commit-back push uses the default GITHUB_TOKEN, and pushes
+# made with GITHUB_TOKEN do NOT trigger new workflow runs — so this never loops.
+# The `[skip ci]` tag and paths filter are belt-and-suspenders.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraw_wrapper.cpp'
+      - 'compileLibraw.sh'
+      - 'build.js'
+      - 'index.js'
+      - 'worker.js'
+      - 'index.d.ts'
+  workflow_dispatch:
+    inputs:
+      force_libs:
+        description: 'Force rebuild of the LCMS/LibRaw static libraries'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-artifacts
+  cancel-in-progress: false
+
+jobs:
+  build-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake libtool
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 5.0.7
+          actions-cache-folder: emsdk-cache
+
+      - name: Decide whether to rebuild static libs
+        run: |
+          if [ "${{ github.event.inputs.force_libs }}" = "true" ]; then
+            echo "FORCE_LIBS=1" >> "$GITHUB_ENV"
+          fi
+          BEFORE="${{ github.event.before }}"
+          if [ -n "$BEFORE" ] && git cat-file -e "$BEFORE" 2>/dev/null \
+             && git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qx 'compileLibraw.sh'; then
+            echo "compileLibraw.sh changed -> forcing LCMS/LibRaw rebuild"
+            echo "FORCE_LIBS=1" >> "$GITHUB_ENV"
+          fi
+
+      - run: npm ci
+
+      - name: Build wasm
+        run: bash compileLibraw.sh
+
+      - name: Unit test
+        run: npm test
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Integration test
+        run: npm run test:integration
+
+      - name: Commit rebuilt artifacts
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist libraw.wasm libraw.js libs includes
+          if git diff --cached --quiet; then
+            echo "No artifact changes to commit."
+          else
+            git commit -m "ci: rebuild wasm artifacts [skip ci]"
+            git push
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+# Build the wasm from source and run the full test suite on every PR.
+# This is verification only — it never commits. Built artifacts are regenerated
+# and committed to main by build-artifacts.yml when the PR merges, so contributors
+# do not need to build or commit any binaries themselves.
+
+on:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed to diff against the PR base
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake libtool
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 5.0.7
+          actions-cache-folder: emsdk-cache
+
+      - name: Force static-lib rebuild if the build script changed
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if [ -n "$BASE" ] && git cat-file -e "$BASE" 2>/dev/null \
+             && git diff --name-only "$BASE" HEAD | grep -qx 'compileLibraw.sh'; then
+            echo "compileLibraw.sh changed -> forcing LCMS/LibRaw rebuild"
+            echo "FORCE_LIBS=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Notice if PR modifies built artifacts
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if [ -n "$BASE" ] && git cat-file -e "$BASE" 2>/dev/null \
+             && git diff --name-only "$BASE" HEAD | grep -qE '^(dist/|libraw\.wasm|libraw\.js|libs/|includes/)'; then
+            echo "::warning::This PR modifies built artifacts (dist/, libraw.wasm, …). You don't need to — CI rebuilds and commits them on merge."
+          fi
+
+      - run: npm ci
+
+      - name: Build wasm
+        run: bash compileLibraw.sh
+
+      - name: Unit test (worker reply routing)
+        run: npm test
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Integration test (real decode)
+        run: npm run test:integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+# On a v* tag: build the wasm from source, run the tests, publish to npm with
+# provenance via OIDC trusted publishing (no NPM_TOKEN secret required — the
+# package's Trusted Publisher is configured on npmjs.com), and cut a GitHub
+# Release with the built artifacts attached.
+#
+# Cut a release with:  npm version <patch|minor|major> && git push --follow-tags
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write # create the GitHub Release
+  id-token: write # OIDC for npm provenance / trusted publishing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake libtool
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 5.0.7
+          actions-cache-folder: emsdk-cache
+
+      - run: npm ci
+
+      - name: Build wasm from source
+        run: bash compileLibraw.sh
+
+      - name: Unit test
+        run: npm test
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Integration test
+        run: npm run test:integration
+
+      - name: Upgrade npm (trusted publishing needs npm >= 11.5)
+        run: npm install -g npm@latest
+
+      - name: Publish to npm (provenance via OIDC)
+        run: npm publish --provenance --access public
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            libraw.wasm
+            dist/**

--- a/compileLibraw.sh
+++ b/compileLibraw.sh
@@ -2,68 +2,78 @@
 
 set -e
 
-rm -rf libs includes LibRawSource lcms2 2>/dev/null || true
-mkdir libs
-mkdir includes
+#---------------------------------------------------------------------------------
+# Stage A: Build the LCMS + LibRaw static libraries with Emscripten.
+#
+# These only change when the pinned versions (or this script) change, so when
+# libs/ is already populated we reuse it and jump straight to linking the wrapper.
+# Set FORCE_LIBS=1 to force a full rebuild (CI sets this automatically whenever
+# compileLibraw.sh itself changes).
+#---------------------------------------------------------------------------------
+if [ "${FORCE_LIBS:-0}" = "1" ] || [ ! -f libs/libraw.a ] || [ ! -f libs/liblcms2.a ]; then
+	echo -e "\n==> Building LCMS + LibRaw static libraries from source..."
+	rm -rf libs includes LibRawSource lcms2 2>/dev/null || true
+	mkdir libs
+	mkdir includes
 
+	#-------------------------------------------------------------------------------
+	# 0) Configure and Build LCMS with Emscripten
+	#-------------------------------------------------------------------------------
+	echo -e "\n==> Cloning LCMS from GitHub (lcms2.19.1)..."
+	git clone --branch lcms2.19.1 --depth 1 https://github.com/mm2/Little-CMS.git lcms2
+	cd lcms2
+	command -v libtoolize >/dev/null 2>&1 && libtoolize || glibtoolize # MacOS fallback
+
+	autoreconf -fi
+	# 2) Configure and make with Emscripten
+	emconfigure ./configure --host=wasm32-unknown-emscripten \
+	  --disable-shared
+	emmake make -j8
+
+	cp -R src/.libs/* ../libs/
+	cp -R include/* ../includes/
+	cd ..
+
+	#-------------------------------------------------------------------------------
+	# 1) Download & Prepare LibRaw
+	#-------------------------------------------------------------------------------
+	echo -e "\n==> Cloning LibRaw from GitHub (0.22.1)..."
+	git clone --branch 0.22.1 --depth 1 https://github.com/LibRaw/LibRaw.git LibRawSource
+
+	pushd LibRawSource
+
+	echo -e "\n==> Generating configure script from configure.ac..."
+	# Generate ./configure from configure.ac
+	command -v libtoolize >/dev/null 2>&1 && libtoolize || glibtoolize # MacOS fallback
+	autoreconf -i
+
+	#-------------------------------------------------------------------------------
+	# 2) Configure and Build LibRaw with Emscripten
+	#-------------------------------------------------------------------------------
+	echo -e "\n==> Configuring LibRaw with Emscripten..."
+	emconfigure ./configure \
+	  --host=wasm32-unknown-emscripten \
+	  --enable-openmp \
+	  --enable-lcms \
+	  --disable-shared \
+	  --disable-examples \
+	  CFLAGS="-O3 -flto -ffast-math -msimd128 -DNDEBUG -DUSE_LCMS2 -I../includes" \
+	  CXXFLAGS="-O3 -flto -ffast-math -msimd128 -DNDEBUG -DUSE_LCMS2 -I../includes" \
+	  LDFLAGS="-s USE_PTHREADS=1 -lpthread -L../libs/ -llcms2"
+
+	echo -e "\n==> Building LibRaw..."
+	emmake make -j8
+
+	# Copy artifacts out of the source folder for convenience
+	cp -R lib/.libs/* ../libs/
+	cp -R libraw ../includes/
+	popd  # out of LibRawSource
+else
+	echo -e "\n==> Reusing existing libs/ + includes/ (set FORCE_LIBS=1 to rebuild them)."
+fi
 
 #---------------------------------------------------------------------------------
-# 0) Configure and Build LCMS with Emscripten
-#---------------------------------------------------------------------------------
-echo -e "\n==> Cloning LCMS from GitHub (lcms2.19.1)..."
-git clone --branch lcms2.19.1 --depth 1 https://github.com/mm2/Little-CMS.git lcms2
-cd lcms2
-command -v libtoolize >/dev/null 2>&1 && libtoolize || glibtoolize # MacOS fallback
-
-autoreconf -fi
-# 2) Configure and make with Emscripten
-emconfigure ./configure --host=wasm32-unknown-emscripten \
-  --disable-shared
-emmake make -j8
-
-cp -R src/.libs/* ../libs/
-cp -R include/* ../includes/
-cd ..
-
-
-
-#---------------------------------------------------------------------------------
-# 1) Download & Prepare LibRaw
-#---------------------------------------------------------------------------------
-echo -e "\n==> Cloning LibRaw from GitHub (0.22.1)..."
-git clone --branch 0.22.1 --depth 1 https://github.com/LibRaw/LibRaw.git LibRawSource
-
-pushd LibRawSource
-
-echo -e "\n==> Generating configure script from configure.ac..."
-# Generate ./configure from configure.ac
-command -v libtoolize >/dev/null 2>&1 && libtoolize || glibtoolize # MacOS fallback
-autoreconf -i
-
-#---------------------------------------------------------------------------------
-# 2) Configure and Build LibRaw with Emscripten
-#---------------------------------------------------------------------------------
-echo -e "\n==> Configuring LibRaw with Emscripten..."
-emconfigure ./configure \
-  --host=wasm32-unknown-emscripten \
-  --enable-openmp \
-  --enable-lcms \
-  --disable-shared \
-  --disable-examples \
-  CFLAGS="-O3 -flto -ffast-math -msimd128 -DNDEBUG -DUSE_LCMS2 -I../includes" \
-  CXXFLAGS="-O3 -flto -ffast-math -msimd128 -DNDEBUG -DUSE_LCMS2 -I../includes" \
-  LDFLAGS="-s USE_PTHREADS=1 -lpthread -L../libs/ -llcms2"
-
-echo -e "\n==> Building LibRaw..."
-emmake make -j8
-
-# Copy artifacts out of the source folder for convenience
-cp -R lib/.libs/* ../libs/
-cp -R libraw ../includes/
-popd  # out of LibRawSource
-
-#---------------------------------------------------------------------------------
-# 3) Build the final WASM from libraw_wrapper.cpp
+# Stage B: Build the final WASM from libraw_wrapper.cpp (always runs).
 #---------------------------------------------------------------------------------
 echo -e "\n==> Building libraw.js + libraw.wasm..."
 emcc \

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.5.0",
 			"license": "ISC",
 			"devDependencies": {
-				"esbuild": "^0.28.1"
+				"esbuild": "^0.28.1",
+				"playwright": "^1.56.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -494,6 +495,53 @@
 				"@esbuild/win32-arm64": "0.28.1",
 				"@esbuild/win32-ia32": "0.28.1",
 				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
 	"scripts": {
 		"example": "python -m http.server 9000",
 		"build": "node build.js",
-		"test": "node test/worker-reply-routing.test.mjs"
+		"compile": "bash compileLibraw.sh",
+		"test": "node test/worker-reply-routing.test.mjs",
+		"test:integration": "node test/integration/decode.test.mjs"
 	},
 	"files": [
 		"dist/*"
@@ -25,6 +27,7 @@
   	],
 	"license": "ISC",
 	"devDependencies": {
-		"esbuild": "^0.28.1"
+		"esbuild": "^0.28.1",
+		"playwright": "^1.56.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,11 @@ console.log('Raw sensor data:', rawImageData); // { raw_width, raw_height, width
 - **Memory:** WebAssembly modules can allocate a significant amount of memory. Check your environment’s limits if you work with very large files.
 
 ## Local development
- - If you're making changes in the CPP wrapper, launch `compileLibraw.sh`
- - If you're launching it on MacOS, make sure that emscripten is installed (e.g. `brew install emscripten`) + build dependencies are insalled (e.g. `brew install autoconf automake libtool`)
- - Don't forget to run `npm build` for esbuild installation!
+ - If you're making changes in the CPP wrapper, launch `compileLibraw.sh` (or `npm run compile`). It builds the LCMS + LibRaw static libs once into `libs/`/`includes/` and reuses them on subsequent runs; set `FORCE_LIBS=1` to rebuild them (e.g. after changing pinned versions).
+ - If you're launching it on MacOS, make sure that emscripten is installed (e.g. `brew install emscripten`) + build dependencies are insalled (e.g. `brew install autoconf automake libtool`). The pinned toolchain is Emscripten 5.0.7.
+ - Tests: `npm test` runs the fast worker reply-routing unit test; `npm run test:integration` decodes `example-sony.ARW` in headless Chromium (run `npx playwright install chromium` first).
+
+## CI/CD
+ - **PRs** (`ci.yml`): the wasm is built from source and the full test suite runs on every pull request — so you do **not** need to build or commit any binaries (`dist/`, `libraw.wasm`, …). CI regenerates them.
+ - **main** (`build-artifacts.yml`): when a build-affecting file changes on `main`, CI rebuilds the wasm and commits the regenerated artifacts back, keeping the checked-in binaries authoritative.
+ - **Releases** (`release.yml`): pushing a `v*` tag builds from source, tests, and publishes to npm (with provenance, via OIDC trusted publishing) plus a GitHub Release. Cut one with `npm version <patch|minor|major> && git push --follow-tags`.

--- a/test/integration/decode.test.mjs
+++ b/test/integration/decode.test.mjs
@@ -1,0 +1,147 @@
+// Integration test: drive the real built module (dist/) in a headless browser
+// against the example Sony RAW, asserting decode output and the concurrency /
+// instance-reuse / dispose invariants.
+//
+// The module is built for `web,worker` and uses pthreads + SharedArrayBuffer, so
+// it cannot run in Node — we serve dist/ over HTTP with the COOP/COEP headers
+// cross-origin isolation requires, and drive it with Playwright's Chromium.
+//
+//   npm run test:integration
+//
+// CI installs the browser with `npx playwright install --with-deps chromium`.
+// Set PW_CHANNEL=chrome to use a locally installed Google Chrome instead.
+
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const FIXTURE = 'example-sony.ARW';
+const MIME = {
+	'.js': 'text/javascript', '.mjs': 'text/javascript', '.wasm': 'application/wasm',
+	'.html': 'text/html', '.json': 'application/json', '.map': 'application/json',
+	'.arw': 'application/octet-stream',
+};
+
+const PAGE = `<!doctype html><meta charset=utf-8><title>decode</title>
+<script type="module">
+import LibRaw from './dist/index.js';
+const withTimeout = (p, ms, label) => Promise.race([
+	p, new Promise((_, r) => setTimeout(() => r(new Error('TIMEOUT ' + label)), ms)),
+]);
+(async () => {
+	try {
+		const buf = await (await fetch('./${FIXTURE}')).arrayBuffer();
+		// open() transfers (detaches) the input, so make independent copies up front.
+		const bytes = () => new Uint8Array(buf.slice(0));
+
+		const raw = new LibRaw();
+		await raw.open(bytes(), { useCameraWb: true });
+		const meta = await raw.metadata(true);
+		const img = await raw.imageData();
+		const rawImg = await raw.rawImageData();
+		const thumb = await raw.thumbnailData();
+
+		// Concurrency: the exact Promise.all scenario that used to hang.
+		const reuse = new LibRaw();
+		await reuse.open(bytes(), { useCameraWb: true, halfSize: true });
+		const [cMeta, cImg] = await withTimeout(
+			Promise.all([reuse.metadata(), reuse.imageData()]), 20000, 'Promise.all');
+
+		// Instance reuse: a 2nd open() on the same instance must reflect new settings.
+		await reuse.open(bytes(), { useCameraWb: true, halfSize: false });
+		const reImg = await reuse.imageData();
+
+		// dispose() must reject in-flight calls instead of hanging.
+		const d = new LibRaw();
+		await d.open(bytes(), {});
+		const inflight = d.metadata();
+		d.dispose();
+		let disposedRejected = false;
+		await inflight.catch(() => { disposedRejected = true; });
+
+		window.__RESULT = {
+			ok: true,
+			model: meta?.camera_model,
+			tsYear: meta?.timestamp instanceof Date ? meta.timestamp.getUTCFullYear() : null,
+			tsIso: meta?.timestamp instanceof Date ? meta.timestamp.toISOString() : null,
+			lens: meta?.lens?.Lens,
+			imgW: img?.width, imgH: img?.height, imgLen: img?.data?.length, imgCtor: img?.data?.constructor?.name,
+			rawLen: rawImg?.data?.length, rawCtor: rawImg?.data?.constructor?.name,
+			thumbW: thumb?.width, thumbH: thumb?.height, thumbFmt: thumb?.format,
+			concMeta: cMeta?.camera_model, concImgW: cImg?.width,
+			reHalfW: cImg?.width, reFullW: reImg?.width,
+			disposedRejected,
+		};
+	} catch (e) { window.__RESULT = { ok: false, error: String(e && e.message || e), stack: e && e.stack }; }
+})();
+</script>`;
+
+const server = http.createServer(async (req, res) => {
+	res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+	res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+	res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+	const url = decodeURIComponent(req.url.split('?')[0]);
+	if (url === '/' || url === '/index.html') {
+		res.setHeader('Content-Type', 'text/html');
+		return res.end(PAGE);
+	}
+	try {
+		const p = normalize(join(ROOT, url));
+		if (!p.startsWith(ROOT)) { res.statusCode = 403; return res.end('forbidden'); }
+		const data = await readFile(p);
+		res.setHeader('Content-Type', MIME[extname(p).toLowerCase()] || 'application/octet-stream');
+		res.end(data);
+	} catch { res.statusCode = 404; res.end('not found'); }
+});
+
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const launchOpts = { headless: true };
+if (process.env.PW_CHANNEL) launchOpts.channel = process.env.PW_CHANNEL;
+const browser = await chromium.launch(launchOpts);
+const page = await browser.newPage();
+const logs = [];
+page.on('console', (m) => { if (m.type() === 'error') logs.push('[console.error] ' + m.text()); });
+page.on('pageerror', (e) => logs.push('[pageerror] ' + e.message));
+
+let r;
+try {
+	await page.goto(`http://localhost:${port}/`);
+	await page.waitForFunction('window.__RESULT !== undefined', { timeout: 120000 });
+	r = await page.evaluate('window.__RESULT');
+} catch (e) {
+	r = { ok: false, error: 'driver: ' + e.message };
+} finally {
+	await browser.close();
+	server.close();
+}
+
+if (logs.length) console.log(logs.join('\n'));
+console.log(JSON.stringify(r, null, 2));
+
+// Assertions
+const checks = [];
+const check = (cond, msg) => checks.push({ ok: !!cond, msg });
+check(r && r.ok, 'page ran without error');
+if (r && r.ok) {
+	check(r.model === 'ILME-FX30', `model is ILME-FX30 (got ${r.model})`);
+	check(r.tsYear && r.tsYear >= 2020, `timestamp scaled to a real year (got ${r.tsIso})`);
+	check(r.imgW === 6240 && r.imgH === 4168, `imageData full dims 6240x4168 (got ${r.imgW}x${r.imgH})`);
+	check(r.imgCtor === 'Uint8Array', `imageData is Uint8Array (got ${r.imgCtor})`);
+	check(r.rawLen === 6272 * 4168, `rawImageData full mosaic length (got ${r.rawLen})`);
+	check(r.rawCtor === 'Uint16Array', `rawImageData is Uint16Array (got ${r.rawCtor})`);
+	check(r.thumbW === 6192 && r.thumbH === 4128, `thumbnail dims 6192x4128 (got ${r.thumbW}x${r.thumbH})`);
+	check(r.thumbFmt === 'jpeg', `thumbnail format jpeg (got ${r.thumbFmt})`);
+	check(r.concMeta === 'ILME-FX30' && r.concImgW === 3120, 'concurrent Promise.all resolved with correct payloads');
+	check(r.reHalfW === 3120 && r.reFullW === 6240, `instance reuse reflects new settings (half=${r.reHalfW}, full=${r.reFullW})`);
+	check(r.disposedRejected, 'dispose() rejected the in-flight call');
+}
+
+const failed = checks.filter((c) => !c.ok);
+for (const c of checks) console.log(`  ${c.ok ? 'ok  ' : 'FAIL'} ${c.msg}`);
+console.log(failed.length === 0 ? '\nAll integration checks passed.' : `\n${failed.length} integration check(s) failed.`);
+process.exit(failed.length === 0 ? 0 : 1);


### PR DESCRIPTION
Implements #22. CI now builds and tests the wasm instead of relying on contributors to build and commit it — using the **commit-back** model so the repo keeps its prebuilt, clone-and-use binaries.

## Workflows
- **`ci.yml`** (PR): builds the wasm from source + runs unit and integration tests. Verification only, no commit. Contributors don't need to build/commit binaries; a soft warning fires if a PR touches built artifacts.
- **`build-artifacts.yml`** (push to `main`): rebuilds and **commits the regenerated artifacts back** to `main`. Pushes with `GITHUB_TOKEN` (so it can't re-trigger itself), skips empty commits, and auto-forces a static-lib rebuild when `compileLibraw.sh` changes. `workflow_dispatch` with a `force_libs` input is available for manual rebuilds.
- **`release.yml`** (`v*` tag): builds from source, tests, then `npm publish --provenance` via **OIDC trusted publishing** (no `NPM_TOKEN` — you've configured the Trusted Publisher on npm) + a GitHub Release.

## Supporting changes
- **`compileLibraw.sh`** split into Stage A (LCMS/LibRaw static libs) and Stage B (wrapper link). Stage A is skipped when `libs/` already exist → common build path ~30s vs ~12min; `FORCE_LIBS=1` forces it.
- **`test/integration/decode.test.mjs`** — headless-Chromium decode of `example-sony.ARW`, asserting metadata/imageData/rawImageData/thumbnail + concurrency, instance-reuse, timestamp, and `dispose()`. Wired as `npm run test:integration` (Playwright added as a devDependency).
- README documents the build/test/CI/release flow.

## Verified locally
- Cache-reuse build path: Stage A skipped, wasm relinked ✅
- `npm test` — 4/4 ✅
- `npm run test:integration` — 12/12 checks pass (model, timestamp 2023, imageData 6240×4168, rawImageData 26,141,696, thumbnail 6192×4128, concurrent `Promise.all`, instance reuse, `dispose()`) ✅

## ⚠️ One-time GitHub setting required
For the commit-back to push to `main`: **Settings → Actions → General → Workflow permissions → "Read and write permissions"**. (If you later add branch protection on `main`, add a bypass for `github-actions[bot]`.)

Note: merging this PR changes `compileLibraw.sh`, which will trigger `build-artifacts.yml` and do a first full from-source rebuild on `main` — a good end-to-end smoke test of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)